### PR TITLE
Fix references

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ val commitHash = kotlin.run {
 val pluginComingVersion = "0.1.3"
 val pluginVersion = if (isCI) "$pluginComingVersion-$commitHash" else pluginComingVersion
 val packageName = "rs.pest"
-val kotlinVersion = "1.2.70"
+val kotlinVersion = "1.3.21"
 
 group = packageName
 version = pluginVersion
@@ -33,7 +33,7 @@ plugins {
 	java
 	id("org.jetbrains.intellij") version "0.4.4"
 	id("org.jetbrains.grammarkit") version "2018.3.1"
-	kotlin("jvm") version "1.2.70"
+	kotlin("jvm") version "1.3.21"
 }
 
 allprojects {
@@ -47,6 +47,9 @@ allprojects {
 				val root = "/home/ice1000/.local/share/JetBrains/Toolbox/apps"
 				localPath = "$root/IDEA-C/ch-0/191.5849.21"
 				alternativeIdePath = "$root/PyCharm-C/ch-0/191.5849.23"
+			}
+			"schle" -> {
+				version = "191.5849.21"
 			}
 		}
 

--- a/grammar/pest.bnf
+++ b/grammar/pest.bnf
@@ -16,15 +16,64 @@
   tokenTypeClass="rs.pest.psi.PestTokenType"
 }
 
-grammar_rules ::=  grammar_rule+
+grammar_rules ::=  grammar_rule+ {
+	pin=1
+	recoverWhile=grammar_rules_recover
+}
 
-grammar_body  ::= OPENING_BRACE expression CLOSING_BRACE { pin=1 }
+grammar_body  ::= OPENING_BRACE expression CLOSING_BRACE { pin=1
+	recoverWhile=grammar_body_recover
+}
+
+private grammar_body_recover ::= !(rule_name )
+
 grammar_rule  ::=
-	(identifier | builtin) ASSIGNMENT_OPERATOR modifier? grammar_body {
+	rule_name ASSIGNMENT_OPERATOR modifier? grammar_body {
 	implements=["com.intellij.psi.PsiNameIdentifierOwner"]
 	mixin="rs.pest.psi.impl.PestGrammarRuleMixin"
-	pin=2
+	pin=1
+	recoverWhile=grammar_rule_recover
 }
+private rule_name ::=
+	  valid_rule_name
+	| overwritable_rule_name
+	| fixed_builtin_rule_name
+	{	pin=1 }
+
+fixed_builtin_rule_name ::=
+    commands
+  | PUSH_TOKEN
+  | PEEK_TOKEN
+  |	ANY_TOKEN
+  | EOI_TOKEN
+  |	SOI_TOKEN
+  |	DROP_TOKEN
+  |	ASCII_TOKEN
+  |	NEWLINE_TOKEN
+  |	ASCII_DIGIT_TOKEN
+  |	ASCII_ALPHA_TOKEN
+  |	ASCII_ALPHANUMERIC_TOKEN
+  |	ASCII_NONZERO_DIGIT_TOKEN
+  |	ASCII_BIN_DIGIT_TOKEN
+  |	ASCII_OCT_DIGIT_TOKEN
+  |	ASCII_HEX_DIGIT_TOKEN
+  |	ASCII_ALPHA_UPPER_TOKEN
+  |	ASCII_ALPHA_LOWER_TOKEN
+  {
+		mixin="rs.pest.psi.impl.PestFixedBuiltinRuleNameMixin"
+	}
+overwritable_rule_name ::=
+    WHITESPACE_TOKEN
+  | COMMENT_TOKEN
+  {
+		mixin="rs.pest.psi.impl.PestOverwritableRuleNameMixin"
+	}
+valid_rule_name ::= IDENTIFIER_TOKEN {
+	mixin="rs.pest.psi.impl.PestRuleNameMixin"
+	}
+
+private grammar_rule_recover ::= !(rule_name )
+private grammar_rules_recover ::= !(rule_name  ASSIGNMENT_OPERATOR)
 
 modifier ::=
 	SILENT_MODIFIER |

--- a/grammar/pest.flex
+++ b/grammar/pest.flex
@@ -31,7 +31,7 @@ import static com.intellij.psi.TokenType.WHITE_SPACE;
 
 WHITE_SPACE=[\ \t\f\r\n]
 INTEGER=[0-9]+
-IDENTIFIER=[a-zA-Z][a-zA-Z_0-9]*
+IDENTIFIER=[a-zA-Z_][a-zA-Z_0-9]*
 STRING_UNICODE=\\((u\{{HEXDIGIT}{2,6}\})|(x{HEXDIGIT}{2}))
 STRING_INCOMPLETE=\"([^\"\\]|(\\[^])|{STRING_UNICODE})*
 CHAR_INCOMPLETE='([^\\\'\x00-\x1F\x7F]|\\[^\x00-\x1F\x7F]+|{STRING_UNICODE})?

--- a/res/rs/pest/pest-bundle.properties
+++ b/res/rs/pest/pest-bundle.properties
@@ -22,6 +22,7 @@ pest.highlighter.settings.non-atomic=Rule names//Non atomic
 pest.annotator.overwrite=Overwriting a built-in rule
 pest.annotator.unresolved=Unresolved reference
 pest.annotator.empty-char=Character literals cannot be empty
+pest.annotator.rule-contains-error=Rule {0} contains a syntax error
 pest.inspection.duplicate-rule=Rule {0} is defined more than once
 pest.actions.new-file.name=Pest Grammar File
 pest.actions.new-file.title=New Pest Grammar File

--- a/src/rs/pest/editing/pest-annotator.kt
+++ b/src/rs/pest/editing/pest-annotator.kt
@@ -4,18 +4,24 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiErrorElement
+import org.jetbrains.uast.findContaining
 import rs.pest.PestBundle
 import rs.pest.PestHighlighter
 import rs.pest.psi.PestCharacter
+import rs.pest.psi.PestValidRuleName
+import rs.pest.psi.impl.PestFixedBuiltinRuleNameMixin
 import rs.pest.psi.impl.PestGrammarRuleMixin
 import rs.pest.psi.impl.PestIdentifierMixin
+import rs.pest.psi.impl.PestRuleNameMixin
 
 class PestAnnotator : Annotator {
 	override fun annotate(element: PsiElement, holder: AnnotationHolder) {
 		when (element) {
-			is PestGrammarRuleMixin -> grammarRule(element, holder)
 			is PestIdentifierMixin -> identifier(element, holder)
 			is PestCharacter -> char(element, holder)
+			is PestFixedBuiltinRuleNameMixin -> fixedBuiltInRuleName(element,holder)
+			is PestRuleNameMixin -> validRuleName(element,holder)
 		}
 	}
 
@@ -23,6 +29,31 @@ class PestAnnotator : Annotator {
 		if (element.textLength <= 2) holder.createErrorAnnotation(element, PestBundle.message("pest.annotator.empty-char")).apply {
 			textAttributes = PestHighlighter.UNRESOLVED
 			highlightType = ProblemHighlightType.ERROR
+		}
+	}
+	private fun fixedBuiltInRuleName(element: PestFixedBuiltinRuleNameMixin, holder: AnnotationHolder) {
+		holder.createErrorAnnotation(element, PestBundle.message("pest.annotator.overwrite")).run {
+			highlightType = ProblemHighlightType.ERROR
+		}
+	}
+	private fun validRuleName(element: PestRuleNameMixin, holder: AnnotationHolder) {
+		val rule = element.parent as PestGrammarRuleMixin
+		holder.createInfoAnnotation(element, rule.type.help()).textAttributes = rule.type.highlight
+		if( containsError(element.parent)){
+			holder.createErrorAnnotation(element, PestBundle.message("pest.annotator.rule-contains-error",element.text)).run {
+				highlightType = ProblemHighlightType.GENERIC_ERROR
+			}
+		}
+	}
+
+	private fun containsError(node : PsiElement) : Boolean {
+		return node.children.any(){
+			when (it) {
+				is PsiErrorElement -> true
+				else -> false
+			}
+		} || node.children.any(){
+			containsError(it)
 		}
 	}
 
@@ -35,13 +66,5 @@ class PestAnnotator : Annotator {
 			return
 		}
 		holder.createInfoAnnotation(element, null).textAttributes = rule.type.highlight
-	}
-
-	private fun grammarRule(element: PestGrammarRuleMixin, holder: AnnotationHolder) {
-		val nameIdentifier = element.nameIdentifier
-		if (nameIdentifier is PestIdentifierMixin) {
-			val type = element.type
-			holder.createInfoAnnotation(nameIdentifier, type.help()).textAttributes = type.highlight
-		} else holder.createInfoAnnotation(nameIdentifier, PestBundle.message("pest.annotator.overwrite"))
 	}
 }

--- a/src/rs/pest/pest-constants.kt
+++ b/src/rs/pest/pest-constants.kt
@@ -29,8 +29,9 @@ import org.jetbrains.annotations.NonNls
 	"DROP",
 	"ASCII",
 	"NEWLINE",
-	"COMMENT",
-	"WHITESPACE",
+// COMMENT and WHITESPACE can be overwritten.
+//	"COMMENT",
+//	"WHITESPACE",
 	"ASCII_DIGIT",
 	"ASCII_ALPHA",
 	"ASCII_ALPHANUMERIC",

--- a/src/rs/pest/pest-highlight.kt
+++ b/src/rs/pest/pest-highlight.kt
@@ -92,6 +92,7 @@ object PestHighlighter : SyntaxHighlighter {
 		PestTokenType.BLOCK_COMMENT -> BLOCK_COMMENT_KEY
 		PestTypes.NUMBER,
 		PestTypes.MINUS -> NUMBER_KEY
+		PestTypes.VALID_RULE_NAME -> IDENTIFIER_KEY
 		in PARENS-> PAREN_KEY
 		in BRACKS -> BRACK_KEY
 		in BRACES -> BRACE_KEY

--- a/src/rs/pest/psi/types.kt
+++ b/src/rs/pest/psi/types.kt
@@ -30,6 +30,7 @@ class PestTokenType(debugName: String) : IElementType(debugName, PestLanguage.IN
 		fun createRule(text: String, project: Project) = fromText(text, project) as PestGrammarRuleMixin
 		fun createBody(text: String, project: Project) = createRule("r=$text", project).grammarBody as PestGrammarBody
 		fun createExpression(text: String, project: Project) = createBody("{$text}", project).expression!!
+		fun createRuleName(text: String, project: Project) = createRule("$text = {\"d\"}", project).nameIdentifier
 	}
 }
 

--- a/testData/parse/NestedComment.txt
+++ b/testData/parse/NestedComment.txt
@@ -2,7 +2,7 @@ FILE
   PsiComment(block comment)('/*Joesph Joestar/*/**/*/ Oh My God*/')
   PsiWhiteSpace('\n')
   PestGrammarRuleImpl(GRAMMAR_RULE)
-    PestIdentifierImpl(IDENTIFIER)
+    PestValidRuleNameImpl(VALID_RULE_NAME)
       PsiElement(IDENTIFIER_TOKEN)('rule')
     PsiElement(ASSIGNMENT_OPERATOR)('=')
     PestGrammarBodyImpl(GRAMMAR_BODY)

--- a/testData/parse/Paren.txt
+++ b/testData/parse/Paren.txt
@@ -1,6 +1,6 @@
 FILE
   PestGrammarRuleImpl(GRAMMAR_RULE)
-    PestIdentifierImpl(IDENTIFIER)
+    PestValidRuleNameImpl(VALID_RULE_NAME)
       PsiElement(IDENTIFIER_TOKEN)('a')
     PsiWhiteSpace(' ')
     PsiElement(ASSIGNMENT_OPERATOR)('=')

--- a/testData/parse/SimpleRule.txt
+++ b/testData/parse/SimpleRule.txt
@@ -1,6 +1,6 @@
 FILE
   PestGrammarRuleImpl(GRAMMAR_RULE)
-    PestIdentifierImpl(IDENTIFIER)
+    PestValidRuleNameImpl(VALID_RULE_NAME)
       PsiElement(IDENTIFIER_TOKEN)('rule')
     PsiWhiteSpace(' ')
     PsiElement(ASSIGNMENT_OPERATOR)('=')


### PR DESCRIPTION
This fixes #9 .

Enable renaming through a rule definition

Remove the `PsiNameIdentifierOwner` from the `PestIdentifierMixin`.
Adapt the grammar so that the rule name is not also an identifier that references this rule.
For renaming [we only need](http://www.jetbrains.org/intellij/sdk/docs/reference_guide/custom_language_support/rename_refactoring.html)
`setName` on the grammar rule and
`handleElementRename` on the the identifiers that reference the rule.

Enable more recovery in the grammar.

Allow COMMENT and WHITESPACE for renaming because these rules can be overwritten.